### PR TITLE
Update backfills docs with more up to date info on single runs

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/backfills.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/backfills.mdx
@@ -42,9 +42,7 @@ By default, if you launch a backfill that covers `N` partitions, Dagster will la
 Dagster supports backfills that execute as a single run that covers a range of partitions, such as executing a backfill as a single Snowflake query. After the run completes, Dagster will track that all the partitions have been filled.
 
 <Note>
-  Single-run backfills only work for backfills that target assets directly, i.e.
-  those launched from the asset graph or asset page. Backfills launched from the
-  Job page will not respect the backfill policies of assets included in the job.
+  Single-run backfills only work if they are launched from the asset graph or asset page, or if the assets are part of an asset job that shares the same backfill policy across all included assets.
 </Note>
 
 To get this behavior, you need to:

--- a/docs/content/concepts/partitions-schedules-sensors/backfills.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/backfills.mdx
@@ -42,7 +42,9 @@ By default, if you launch a backfill that covers `N` partitions, Dagster will la
 Dagster supports backfills that execute as a single run that covers a range of partitions, such as executing a backfill as a single Snowflake query. After the run completes, Dagster will track that all the partitions have been filled.
 
 <Note>
-  Single-run backfills only work if they are launched from the asset graph or asset page, or if the assets are part of an asset job that shares the same backfill policy across all included assets.
+  Single-run backfills only work if they are launched from the asset graph or
+  asset page, or if the assets are part of an asset job that shares the same
+  backfill policy across all included assets.
 </Note>
 
 To get this behavior, you need to:


### PR DESCRIPTION
I noticed the docs of the backfill page for single runs are out of date with 1.8 based on the changes here: https://github.com/dagster-io/dagster/pull/21259

Starting this PR to correct that - potentially should add an example when using with jobs